### PR TITLE
Add CSV of people mentioned in episode 708

### DIFF
--- a/data/episode/708/vovr-ep708-people.csv
+++ b/data/episode/708/vovr-ep708-people.csv
@@ -1,0 +1,26 @@
+episode,starttime,endtime,type,sub-type,identifier,attributes,relationship-1,relationship-1-attributes,relationship-2,relationship-2-attributes
+708,,,person,interviewee,Sam Roberts,"skills:game/play curator, game designer",org:IndieCade,"roles:[festival director, curator]",,
+708,,,person,interviewer,Kent Bye,,,,,
+708,,,date,interview,2018-10-13,,,,,
+708,,,date,publish,2018-10-23,,,,,
+708,140.92,169.48,person,mention,Stephanie Barish,,org:IndieCade,roles:CEO,person:Tracy Fullerton,roles:friend
+708,163.209,184.269,person,mention,Tracy Fullerton,,game:The Night Journey,roles:creator,person:Bill Viola,roles:collaborator
+708,169.48,180.1,person,mention,Bill Viola,skills:film video artist,game:The Night Journey,roles:creator,person:Tracy Fullerton,roles:collaborator
+708,180.1,187.81,person,mention,Tracy Fullerton,,"game:Walden, A Game",roles:creator,,
+708,184.269,191.92,person,mention,Tracy Fullerton,,"relationship:[Stephanie Barish, Celia Pierce]",actions:connected,"relationship:[Stephanie Barish, Sam Roberts]",actions:connected
+708,187.81,219.069,person,mention,Stephanie Barish,,person:Celia Pearce,introduced-by:Tracy Fullerton,person:Sam Roberts,introduced-by:Tracy Fullerton
+708,187.81,219.069,person,mention,Celia Pearce,skills:game/play curator,person:Stephanie Barish,introduced-by:Tracy Fullerton,,
+708,187.81,219.069,person,mention,Sam Roberts,,person:Stephanie Barish,introduced-by:Tracy Fullerton,,
+708,263.8,274.24,person,mention,Mark Bolas,,entity:a VR lab,,,
+708,274.24,279.88,person,mention,Nonny de la Peña,,,,,
+708,335.92,409.74,person,mention,Liam Burke,,game:unnamed,"roles:creator, type: tabletop RPG",,
+708,403.65,444.15,person,mention,Pietro Riva,"skills:game developer, from:Milan Italy",,,,
+708,476.789,490.5,person,mention,Doug Wilson,skills:game creator,person:Nils Deneken,roles:collaborator,,
+708,482.189,490.5,person,mention,Nils Deneken,skills:game creator,person:Doug Wilson,roles:collaborator,,
+708,542.329,550.069,person,mention,Michael Mateas,,org:UC Santa Cruz Expressive Intelligence Studio,roles:runs,topic:AI,
+708,625.459,647.32,person,mention,Jenova Chen,,game:flOw,roles:creator,topic:AI,
+708,1239.34,1245.61,person,mention,Kent Bye,,person:Noah (Nelson?),roles:interviewee,,
+708,1239.34,1245.61,person,mention,Noah (Nelson?),,person:Kent Bye,roles:interviewer,,
+708,1616.309,1650.27,person,mention,Sutu,"skills:AR/VR artist, aka: Stuart Campbell",event:Spatial Reality: Artists Explore the Future of XR,"roles:artist, location: Pasadena CA",topic:AR,
+708,1782.72,1832.999,person,mention,Joseph Campbell,skills:author,concept:hero's journey,roles:creator,,
+708,2207.63,2718.92,person,mention,Sam Roberts,,,,,

--- a/data/episode/708/vovr-ep708-yt-transcript.xml
+++ b/data/episode/708/vovr-ep708-yt-transcript.xml
@@ -61,7 +61,7 @@ Santa Monica California so with that let&#39;s go ahead and dive right in
 I&#39;m Sam Roberts and I&#39;m the festival director for IndieCade which means I
 </text>
 <text start="96.82" dur="4.5">
-generally am in charge of our content in decayed is the International Festival of
+generally am in charge of our content. IndieCade is the International Festival of
 </text>
 <text start="101.32" dur="5.01">
 play so what that means is we are looking for play and playful experiences
@@ -90,9 +90,9 @@ and performance games connecting that with the table game in the RPG community
 <text start="137.68" dur="3.24">
 and getting all this feedback so that&#39;s sort of like what we&#39;re about and what
 </text>
-<text start="140.92" dur="3.12">we do Stephanie bearish is the CEO started in</text>
+<text start="140.92" dur="3.12">we do. Stephanie Barish is the CEO started In-</text>
 <text start="144.04" dur="5.479">
-decayed in the mid 2000s because she had been working with a lot of sort of like
+dieCade in the mid 2000s because she had been working with a lot of sort of like
 </text>
 <text start="149.519" dur="5.561">
 new-age animation students who were making not like animated short films but
@@ -104,10 +104,10 @@ not video games right like interactive pieces of digital art and they didn&#39;t
 have a home for them and she was like this stuff should have a home and she
 </text>
 <text start="163.209" dur="6.271">
-was friends with Tracy Fullerton Tracy made a game at that time called the
+was friends with Tracy Fullerton. Tracy made a game at that time called The
 </text>
 <text start="169.48" dur="5.569">
-night journey which is a video game collaboration with Bill viola who&#39;s a
+Night Journey which is a video game collaboration with Bill Viola who&#39;s a
 </text>
 <text start="175.049" dur="5.051">
 film video artist and so it&#39;s like essentially like a museum video art
@@ -116,10 +116,10 @@ film video artist and so it&#39;s like essentially like a museum video art
 exhibit that you could play on the PlayStation Tracy recently everyone&#39;s
 </text>
 <text start="184.269" dur="3.541">
-been talking about it cuz she made walden a game so tracy connected
+been talking about it cuz she made Walden, A Game so Tracy connected
 </text>
 <text start="187.81" dur="4.11">
-Stefanie with Celia Pierce and myself who from different directions had been
+Stephanie with Celia Pearce and myself who from different directions had been
 </text>
 <text start="191.92" dur="6.21">
 involved in curating play video game and play like experiences in other venues
@@ -173,13 +173,13 @@ like we showed use of force seven years ago right so we showed it
 before there was a dev oculus kit we were using the technology from Mark
 </text>
 <text start="269.56" dur="4.68">
-poulos&#39;s VR lab that is basically the grandfather of the oculus technology
+Bolas&#39;s VR lab that is basically the grandfather of the Oculus technology.
 </text>
 <text start="274.24" dur="5.64">
-Nani came and showed the piece she won an award and then last night Nani was
+Nonny came and showed the piece she won an award and then last night Nonny was
 </text>
 <text start="279.88" dur="5.28">
-just running around as nani and like great to see her but you know this year
+just running around as Nonny and like great to see her but you know this year
 </text>
 <text start="285.16" dur="7.47">
 we have five 360 basically VR playful light interaction experiences that are
@@ -320,7 +320,7 @@ like exploring essentially like experimental animation and somebody
 who&#39;s interested in like obsessively in like physical mechanics of play Doug
 </text>
 <text start="482.189" dur="4.35">
-Wilson and Nils Denikin came together at that festival and like fell in creative
+Wilson and Nils Deneken came together at that festival and like fell in creative
 </text>
 <text start="486.539" dur="3.961">
 love and like made games together for like six years you know so I feel like
@@ -357,7 +357,7 @@ there bad news also prom week I saw when I went home and then there&#39;s anothe
 about Shakespeare Elsinore so this so that there is artificial intelligence
 </text>
 <text start="542.329" dur="4.8">
-and what the UC Santa Cruz expressive intelligence studio by Michael Mateus is
+and what the UC Santa Cruz Expressive Intelligence Studio by Michael Mateas is
 </text>
 <text start="547.129" dur="2.94">
 working on and so I&#39;m just curious from your perspective like what is happening
@@ -1098,7 +1098,7 @@ that&#39;s sort of my ISM mm-hmm yeah I went to the spatial reality arts show la
 night and there are some augmented reality art pieces and what I found
 </text>
 <text start="1616.309" dur="4.591">
-myself doing was that some of the pieces like sousou&#39;s piece had like 11 pieces
+myself doing was that some of the pieces like Sutu&#39;s piece had like 11 pieces
 </text>
 <text start="1620.9" dur="3.81">
 and you had to to put the pad down and lift it up and then it would add the


### PR DESCRIPTION
See #5 

The main columns are:
- episode
- starttime (in seconds based on the transcript segments)
- type and sub-type (e.g. person, mention)
- identifier (most commonly the person's name)

YouTube links can easily be derived from the starttimes. (If pre-generated links are necessary I can generate those.)

I included additional columns with some more info about each person. The extra columns can be ignored if they're not needed, but I wanted to experiment with adding additional info related to each person. Some tags for relationships include: org: for company/organization, game:, person:, skills:, etc. along with roles or actions for that relationship. It did take a fair amount of additional effort to identify endtimes and relationships which may not be practical to do on many episodes (at least not the way I did it).